### PR TITLE
Build: DexPreOpt only for user builds

### DIFF
--- a/BoardConfigCommon.mk
+++ b/BoardConfigCommon.mk
@@ -45,7 +45,7 @@ TARGET_CPU_CORTEX_A53 := true
 
 # Dex-preoptimization
 ifeq ($(HOST_OS),linux)
-  ifeq ($(TARGET_BUILD_VARIANT),userdebug)
+  ifeq ($(TARGET_BUILD_VARIANT),user)
    ifeq ($(WITH_DEXPREOPT),)
     WITH_DEXPREOPT := true
    endif


### PR DESCRIPTION
Dex pre-optimize does not work well with userdebug CM builds. De-activate it so we can boot it, until we find the root of the cause.